### PR TITLE
Allow get_actions method to accept optional account parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/hyperion",
     "description": "API Client to access Hyperion API endpoints",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "homepage": "https://github.com/wharfkit/hyperion",
     "main": "lib/hyperion.js",
     "module": "lib/hyperion.m.js",

--- a/src/endpoints/v2/v2.ts
+++ b/src/endpoints/v2/v2.ts
@@ -135,7 +135,7 @@ export class HyperionV2HistoryAPIClient {
     }
 
     async get_actions(
-        account: NameType,
+        account?: NameType | null,
         options?: {
             filter?: string
             skip?: number
@@ -150,7 +150,11 @@ export class HyperionV2HistoryAPIClient {
             act_account?: NameType
         }
     ) {
-        const queryParts: string[] = [`account=${account}`]
+        const queryParts: string[] = []
+
+        if (account) {
+            queryParts.push(`account=${account}`)
+        }
 
         for (const [key, value] of Object.entries(options || {})) {
             queryParts.push(`${key}=${value}`)


### PR DESCRIPTION
get_actions doesn't need to have an account input to get all recent actions

Bumped to version 1.0.5